### PR TITLE
Set lazy.nvim lockfile path outside nix stores

### DIFF
--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -30,7 +30,7 @@ in
         ++ lib.optionals hasExtraPackages ["--suffix" "PATH" ":" "${lib.makeBinPath extraPackages}"]
         ++ lib.optionals isolated [
           "--set"
-          "XDG_CONFIG_DIRS"
+          "XDG_CONFIG_HOME"
           "${stdpath.config}"
           "--set"
           "XDG_CACHE_HOME"


### PR DESCRIPTION
## Changes

- fix: reverts to using XDG_CONFIG_HOME
- fix: when running in isolated mode, copy lazy-lock to stdpath state

## Related Issues

- #2
- Fixes #3
